### PR TITLE
Use a pipe to enable non-blocking IO reads

### DIFF
--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -419,7 +419,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
             method=method,
             path=path,
             headers=headers,
-            body_stream=crt_body,
+            body_stream=crt_body, # type: ignore
         )
         return crt_request, body_stream
 

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -3,6 +3,7 @@
 #  pyright: reportMissingTypeStubs=false,reportUnknownMemberType=false
 #  flake8: noqa: F811
 import asyncio
+import os
 from asyncio import Future as AsyncFuture
 from concurrent.futures import Future as ConcurrentFuture
 from collections import deque
@@ -259,7 +260,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
         return response
 
     def _close_input_body(
-        self, future: ConcurrentFuture[int], *, body: "BufferableByteStream | BytesIO"
+        self, future: ConcurrentFuture[int], *, body: "PipeByteStream | BytesIO"
     ) -> None:
         if future.exception(timeout=0):
             body.close()
@@ -336,7 +337,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
 
     async def _marshal_request(
         self, request: http_aio_interfaces.HTTPRequest
-    ) -> tuple["crt_http.HttpRequest", "BufferableByteStream | BytesIO"]:
+    ) -> tuple["crt_http.HttpRequest", "PipeByteStream | BytesIO"]:
         """Create :py:class:`awscrt.http.HttpRequest` from
         :py:class:`smithy_http.aio.HTTPRequest`"""
         headers_list = []
@@ -368,7 +369,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
             # it into the intermediate object that CRT needs. By using
             # asyncio.create_task we'll start the coroutine without having to
             # explicitly await it.
-            crt_body = BufferableByteStream()
+            crt_body = PipeByteStream()
 
             if not isinstance(body, AsyncIterable):
                 body = AsyncBytesReader(body)
@@ -390,7 +391,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
         return crt_request, crt_body
 
     async def _consume_body_async(
-        self, source: AsyncIterable[bytes], dest: "BufferableByteStream"
+        self, source: AsyncIterable[bytes], dest: "PipeByteStream"
     ) -> None:
         try:
             async for chunk in source:
@@ -409,45 +410,35 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
         )
 
 
-# This is adapted from the transcribe streaming sdk
-class BufferableByteStream(BufferedIOBase):
-    """A non-blocking bytes buffer."""
+class PipeByteStream(BufferedIOBase):
+    """A pipe based bytes buffer."""
 
     def __init__(self) -> None:
-        # We're always manipulating the front and back of the buffer, so a deque
-        # will be much more efficient than a list.
-        self._chunks: deque[bytes] = deque()
+        self._read_fd, self._write_fd = os.pipe()
         self._closed = False
-        self._done = False
+
+    def read_fd(self):
+        """The pipe's read file descriptor."""
+        return self._read_fd
 
     def read(self, size: int | None = -1) -> bytes:
-        if self._closed:
-            return b""
+        """This method will block on os.read until data is available in the pipe.
 
-        if len(self._chunks) == 0:
-            if self._done:
-                self.close()
-                return b""
-            else:
-                # When the CRT recieves this, it'll try again
-                raise BlockingIOError("read")
+        Do NOT call this method from native C code that holds the GIL.
+        """
 
-        # We could compile all the chunks here instead of just returning
-        # the one, BUT the CRT will keep calling read until empty bytes
-        # are returned. So it's actually better to just return one chunk
-        # since combining them would have some potentially bad memory
-        # usage issues.
-        result = self._chunks.popleft()
-        if size is not None and size > 0:
-            remainder = result[size:]
-            result = result[:size]
-            if remainder:
-                self._chunks.appendleft(remainder)
+        if size is None or size < 0:
+            result = b""
+            while True:
+                chunk = os.read(self._read_fd, 1024)
+                if not chunk:
+                    break
+                result += chunk
 
-        if self._done and len(self._chunks) == 0:
-            self.close()
-
-        return result
+            return result
+        else:
+            # will return b'' if the pipe has been closed and fully drained.
+            return os.read(self._read_fd, size)
 
     def read1(self, size: int = -1) -> bytes:
         return self.read(size)
@@ -464,7 +455,7 @@ class BufferableByteStream(BufferedIOBase):
     def write(self, buffer: "ReadableBuffer") -> int:
         if not isinstance(buffer, bytes):
             raise ValueError(
-                f"Unexpected value written to BufferableByteStream. "
+                f"Unexpected value written to PipeByteStream. "
                 f"Only bytes are support but {type(buffer)} was provided."
             )
 
@@ -472,7 +463,7 @@ class BufferableByteStream(BufferedIOBase):
             raise IOError("Stream is completed and doesn't support further writes.")
 
         if buffer:
-            self._chunks.append(buffer)
+            os.write(self._write_fd, buffer)  # type: ignore
         return len(buffer)
 
     @property
@@ -481,14 +472,9 @@ class BufferableByteStream(BufferedIOBase):
 
     def close(self) -> None:
         self._closed = True
-        self._done = True
 
-        # Clear out the remaining chunks so that they don't sit around in memory.
-        self._chunks.clear()
+        print("Closing the write side of pipe....")
+        os.close(self._write_fd)
 
     def end_stream(self) -> None:
-        """End the stream, letting any remaining chunks be read before it is closed."""
-        if len(self._chunks) == 0:
-            self.close()
-        else:
-            self._done = True
+        self.close()

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -260,7 +260,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
         return response
 
     def _close_input_body(
-        self, future: ConcurrentFuture[int], *, body: "PipeByteStream | BytesIO"
+        self, future: ConcurrentFuture[int], *, body: "BufferableByteStream | PipeByteStream | BytesIO"
     ) -> None:
         if future.exception(timeout=0):
             body.close()
@@ -337,7 +337,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
 
     async def _marshal_request(
         self, request: http_aio_interfaces.HTTPRequest
-    ) -> tuple["crt_http.HttpRequest", "PipeByteStream | BytesIO"]:
+    ) -> tuple["crt_http.HttpRequest", "BufferableByteStream | PipeByteStream | BytesIO"]:
         """Create :py:class:`awscrt.http.HttpRequest` from
         :py:class:`smithy_http.aio.HTTPRequest`"""
         headers_list = []
@@ -369,7 +369,12 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
             # it into the intermediate object that CRT needs. By using
             # asyncio.create_task we'll start the coroutine without having to
             # explicitly await it.
-            crt_body = PipeByteStream()
+            if hasattr(crt_http, "PipeInputStream"):
+                crt_body = PipeByteStream()
+                body_stream = crt_http.PipeInputStream(crt_body)
+            else:
+                crt_body = BufferableByteStream()
+                body_stream = crt_body
 
             if not isinstance(body, AsyncIterable):
                 body = AsyncBytesReader(body)
@@ -377,7 +382,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
             # Start the read task in the background.
             read_task = asyncio.create_task(self._consume_body_async(body, crt_body))
 
-            # Keep track of the read task so that it doesn't get garbage colllected,
+            # Keep track of the read task so that it doesn't get garbage collected,
             # and stop tracking it once it's done.
             self._async_reads.add(read_task)
             read_task.add_done_callback(self._async_reads.discard)
@@ -386,12 +391,12 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
             method=request.method,
             path=path,
             headers=headers,
-            body_stream=crt_body,
+            body_stream=body_stream,
         )
         return crt_request, crt_body
 
     async def _consume_body_async(
-        self, source: AsyncIterable[bytes], dest: "PipeByteStream"
+        self, source: AsyncIterable[bytes], dest: "BufferableByteStream | PipeByteStream"
     ) -> None:
         try:
             async for chunk in source:
@@ -410,6 +415,90 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
         )
 
 
+# This is adapted from the transcribe streaming sdk
+class BufferableByteStream(BufferedIOBase):
+    """A non-blocking bytes buffer."""
+
+    def __init__(self) -> None:
+        # We're always manipulating the front and back of the buffer, so a deque
+        # will be much more efficient than a list.
+        self._chunks: deque[bytes] = deque()
+        self._closed = False
+        self._done = False
+
+    def read(self, size: int | None = -1) -> bytes:
+        if self._closed:
+            return b""
+
+        if len(self._chunks) == 0:
+            if self._done:
+                self.close()
+                return b""
+            else:
+                # When the CRT recieves this, it'll try again
+                raise BlockingIOError("read")
+
+        # We could compile all the chunks here instead of just returning
+        # the one, BUT the CRT will keep calling read until empty bytes
+        # are returned. So it's actually better to just return one chunk
+        # since combining them would have some potentially bad memory
+        # usage issues.
+        result = self._chunks.popleft()
+        if size is not None and size > 0:
+            remainder = result[size:]
+            result = result[:size]
+            if remainder:
+                self._chunks.appendleft(remainder)
+
+        if self._done and len(self._chunks) == 0:
+            self.close()
+
+        return result
+
+    def read1(self, size: int = -1) -> bytes:
+        return self.read(size)
+
+    def readinto(self, buffer: "WriteableBuffer") -> int:
+        if not isinstance(buffer, memoryview):
+            buffer = memoryview(buffer).cast("B")
+
+        data = self.read(len(buffer))  # type: ignore
+        n = len(data)
+        buffer[:n] = data
+        return n
+
+    def write(self, buffer: "ReadableBuffer") -> int:
+        if not isinstance(buffer, bytes):
+            raise ValueError(
+                f"Unexpected value written to BufferableByteStream. "
+                f"Only bytes are support but {type(buffer)} was provided."
+            )
+
+        if self._closed:
+            raise IOError("Stream is completed and doesn't support further writes.")
+
+        if buffer:
+            self._chunks.append(buffer)
+        return len(buffer)
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def close(self) -> None:
+        self._closed = True
+        self._done = True
+
+        # Clear out the remaining chunks so that they don't sit around in memory.
+        self._chunks.clear()
+
+    def end_stream(self) -> None:
+        """End the stream, letting any remaining chunks be read before it is closed."""
+        if len(self._chunks) == 0:
+            self.close()
+        else:
+            self._done = True
+
 class PipeByteStream(BufferedIOBase):
     """A pipe based bytes buffer."""
 
@@ -417,6 +506,7 @@ class PipeByteStream(BufferedIOBase):
         self._read_fd, self._write_fd = os.pipe()
         self._closed = False
 
+    @property
     def read_fd(self):
         """The pipe's read file descriptor."""
         return self._read_fd

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -259,7 +259,10 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
         return response
 
     def _close_input_body(
-        self, future: ConcurrentFuture[int], *, body: "BufferableByteStream | PipeByteStream | BytesIO"
+        self,
+        future: ConcurrentFuture[int],
+        *,
+        body: "BufferableByteStream | PipeByteStream | BytesIO",
     ) -> None:
         if future.exception(timeout=0):
             body.close()
@@ -336,7 +339,9 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
 
     async def _marshal_request(
         self, request: http_aio_interfaces.HTTPRequest
-    ) -> tuple["crt_http.HttpRequest", "BufferableByteStream | PipeByteStream | BytesIO"]:
+    ) -> tuple[
+        "crt_http.HttpRequest", "BufferableByteStream | PipeByteStream | BytesIO"
+    ]:
         """Create :py:class:`awscrt.http.HttpRequest` from
         :py:class:`smithy_http.aio.HTTPRequest`"""
         headers_list = []
@@ -368,34 +373,60 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
             # it into the intermediate object that CRT needs. By using
             # asyncio.create_task we'll start the coroutine without having to
             # explicitly await it.
-            if hasattr(crt_http, "PipeInputStream"):
-                crt_body = PipeByteStream()
-                body_stream = crt_http.PipeInputStream(crt_body)
-            else:
-                crt_body = BufferableByteStream()
-                body_stream = crt_body
-
             if not isinstance(body, AsyncIterable):
                 body = AsyncBytesReader(body)
 
-            # Start the read task in the background.
-            read_task = asyncio.create_task(self._consume_body_async(body, crt_body))
+            # If the CRT bindings support PipeInputStream, use it to avoid busy waiting.
+            if hasattr(crt_http, "PipeInputStream"):
+                return await self._marshal_request_pipe_input(
+                    body, headers, path, request.method
+                )
+            else:
+                crt_body = BufferableByteStream()
 
-            # Keep track of the read task so that it doesn't get garbage collected,
-            # and stop tracking it once it's done.
-            self._async_reads.add(read_task)
-            read_task.add_done_callback(self._async_reads.discard)
+                # Start the read task in the background.
+                read_task = asyncio.create_task(
+                    self._consume_body_async(body, crt_body)
+                )
+
+                # Keep track of the read task so that it doesn't get garbage collected,
+                # and stop tracking it once it's done.
+                self._async_reads.add(read_task)
+                read_task.add_done_callback(self._async_reads.discard)
 
         crt_request = crt_http.HttpRequest(
             method=request.method,
             path=path,
             headers=headers,
-            body_stream=body_stream,
+            body_stream=crt_body,
         )
         return crt_request, crt_body
 
+    async def _marshal_request_pipe_input(
+        self,
+        body: AsyncIterable[bytes],
+        headers: crt_http.HttpHeaders,
+        path: str,
+        method: str,
+    ):
+        body_stream = PipeByteStream()
+        crt_body = crt_http.PipeInputStream(body_stream)
+        # Start the read task in the background.
+        read_task = asyncio.create_task(self._consume_body_async(body, body_stream))
+        self._async_reads.add(read_task)
+        read_task.add_done_callback(self._async_reads.discard)
+        crt_request = crt_http.HttpRequest(
+            method=method,
+            path=path,
+            headers=headers,
+            body_stream=crt_body,
+        )
+        return crt_request, body_stream
+
     async def _consume_body_async(
-        self, source: AsyncIterable[bytes], dest: "BufferableByteStream | PipeByteStream"
+        self,
+        source: AsyncIterable[bytes],
+        dest: "BufferableByteStream | PipeByteStream",
     ) -> None:
         try:
             async for chunk in source:
@@ -498,8 +529,9 @@ class BufferableByteStream(BufferedIOBase):
         else:
             self._done = True
 
+
 class PipeByteStream(BufferedIOBase):
-    """A pipe based bytes buffer."""
+    """A pipe based bytes stream."""
 
     def __init__(self) -> None:
         self._read_fd, self._write_fd = os.pipe()
@@ -513,7 +545,9 @@ class PipeByteStream(BufferedIOBase):
     def read(self, size: int | None = -1) -> bytes:
         """This method will block on os.read until data is available in the pipe.
 
-        Do NOT call this method from native C code that holds the GIL.
+        Do NOT call read from native C code that holds the GIL.
+
+        Calling read with size None or < 0 will block until the input stream is closed.
         """
 
         if size is None or size < 0:
@@ -549,7 +583,7 @@ class PipeByteStream(BufferedIOBase):
             )
 
         if self._closed:
-            raise IOError("Stream is completed and doesn't support further writes.")
+            raise OSError("Stream is completed and doesn't support further writes.")
 
         if buffer:
             os.write(self._write_fd, buffer)  # type: ignore
@@ -561,8 +595,6 @@ class PipeByteStream(BufferedIOBase):
 
     def close(self) -> None:
         self._closed = True
-
-        print("Closing the write side of pipe....")
         os.close(self._write_fd)
 
     def end_stream(self) -> None:

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -419,7 +419,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
             method=method,
             path=path,
             headers=headers,
-            body_stream=crt_body, # type: ignore
+            body_stream=crt_body,  # type: ignore
         )
         return crt_request, body_stream
 

--- a/packages/smithy-http/src/smithy_http/aio/crt.py
+++ b/packages/smithy-http/src/smithy_http/aio/crt.py
@@ -410,7 +410,7 @@ class AWSCRTHTTPClient(http_aio_interfaces.HTTPClient):
         method: str,
     ):
         body_stream = PipeByteStream()
-        crt_body = crt_http.PipeInputStream(body_stream)
+        crt_body = crt_http.PipeInputStream(body_stream)  # type: ignore
         # Start the read task in the background.
         read_task = asyncio.create_task(self._consume_body_async(body, body_stream))
         self._async_reads.add(read_task)

--- a/packages/smithy-http/tests/unit/aio/test_crt.py
+++ b/packages/smithy-http/tests/unit/aio/test_crt.py
@@ -12,7 +12,7 @@ from awscrt.http import HttpClientStream  # type: ignore
 from smithy_core import URI
 from smithy_http import Fields
 from smithy_http.aio import HTTPRequest
-from smithy_http.aio.crt import AWSCRTHTTPClient, BufferableByteStream, CRTResponseBody
+from smithy_http.aio.crt import AWSCRTHTTPClient, PipeByteStream, CRTResponseBody
 
 
 def test_deepcopy_client() -> None:
@@ -38,62 +38,52 @@ async def test_client_marshal_request() -> None:
 
 
 def test_stream_write() -> None:
-    stream = BufferableByteStream()
+    stream = PipeByteStream()
     stream.write(b"foo")
+    stream.close()
     assert stream.read() == b"foo"
-
-
-def test_stream_reads_individual_chunks() -> None:
-    stream = BufferableByteStream()
-    stream.write(b"foo")
-    stream.write(b"bar")
-    assert stream.read() == b"foo"
-    assert stream.read() == b"bar"
-
-
-def test_stream_empty_read() -> None:
-    stream = BufferableByteStream()
-    with pytest.raises(BlockingIOError):
-        stream.read()
 
 
 def test_stream_partial_chunk_read() -> None:
-    stream = BufferableByteStream()
+    stream = PipeByteStream()
     stream.write(b"foobar")
     assert stream.read(3) == b"foo"
+    stream.close()
     assert stream.read() == b"bar"
 
 
 def test_stream_write_empty_bytes() -> None:
-    stream = BufferableByteStream()
+    stream = PipeByteStream()
     stream.write(b"")
     stream.write(b"foo")
     stream.write(b"")
+    stream.close()
     assert stream.read() == b"foo"
 
 
 def test_stream_write_non_bytes() -> None:
-    stream = BufferableByteStream()
+    stream = PipeByteStream()
     with pytest.raises(ValueError):
         stream.write(memoryview(b"foo"))
 
 
 def test_closed_stream_write() -> None:
-    stream = BufferableByteStream()
+    stream = PipeByteStream()
     stream.close()
     with pytest.raises(IOError):
         stream.write(b"foo")
 
 
 def test_closed_stream_read() -> None:
-    stream = BufferableByteStream()
+    stream = PipeByteStream()
     stream.write(b"foo")
     stream.close()
+    assert stream.read() == b"foo"
     assert stream.read() == b""
 
 
 def test_done_stream_read() -> None:
-    stream = BufferableByteStream()
+    stream = PipeByteStream()
     stream.write(b"foo")
     stream.end_stream()
     assert stream.read() == b"foo"
@@ -101,24 +91,14 @@ def test_done_stream_read() -> None:
 
 
 def test_end_empty_stream() -> None:
-    stream = BufferableByteStream()
+    stream = PipeByteStream()
     stream.end_stream()
     assert stream.read() == b""
 
 
-def test_stream_read1() -> None:
-    stream = BufferableByteStream()
-    stream.write(b"foo")
-    stream.write(b"bar")
-    assert stream.read1() == b"foo"
-    assert stream.read1() == b"bar"
-    with pytest.raises(BlockingIOError):
-        stream.read()
-
-
 def test_stream_readinto_memoryview() -> None:
     buffer = memoryview(bytearray(b"   "))
-    stream = BufferableByteStream()
+    stream = PipeByteStream()
     stream.write(b"foobar")
     stream.readinto(buffer)
     assert bytes(buffer) == b"foo"
@@ -126,20 +106,10 @@ def test_stream_readinto_memoryview() -> None:
 
 def test_stream_readinto_bytearray() -> None:
     buffer = bytearray(b"   ")
-    stream = BufferableByteStream()
+    stream = PipeByteStream()
     stream.write(b"foobar")
     stream.readinto(buffer)
     assert bytes(buffer) == b"foo"
-
-
-def test_end_stream() -> None:
-    stream = BufferableByteStream()
-    stream.write(b"foo")
-    stream.end_stream()
-
-    assert not stream.closed
-    assert stream.read() == b"foo"
-    assert stream.closed
 
 
 async def test_response_body_completed_stream() -> None:

--- a/packages/smithy-http/tests/unit/aio/test_crt.py
+++ b/packages/smithy-http/tests/unit/aio/test_crt.py
@@ -11,7 +11,12 @@ from awscrt.http import HttpClientStream  # type: ignore
 from smithy_core import URI
 from smithy_http import Fields
 from smithy_http.aio import HTTPRequest
-from smithy_http.aio.crt import AWSCRTHTTPClient, BufferableByteStream, CRTResponseBody
+from smithy_http.aio.crt import (
+    AWSCRTHTTPClient,
+    BufferableByteStream,
+    CRTResponseBody,
+    PipeByteStream,
+)
 
 
 def test_deepcopy_client() -> None:
@@ -139,6 +144,36 @@ def test_end_stream() -> None:
     assert not stream.closed
     assert stream.read() == b"foo"
     assert stream.closed
+
+
+def test_pipe_stream_write() -> None:
+    stream = PipeByteStream()
+    stream.write(b"foo")
+    assert stream.read(size=3) == b"foo"
+
+
+def test_pipe_stream_read_all() -> None:
+    stream = PipeByteStream()
+    stream.write(b"foo")
+    stream.write(b"bar")
+    stream.close()
+    assert stream.read() == b"foobar"
+
+
+def test_pipe_stream_write_empty_bytes() -> None:
+    stream = PipeByteStream()
+    stream.write(b"")
+    stream.write(b"foo")
+    stream.write(b"")
+    stream.close()
+    assert stream.read() == b"foo"
+
+
+def test_closed_pipe_stream_write() -> None:
+    stream = PipeByteStream()
+    stream.close()
+    with pytest.raises(IOError):
+        stream.write(b"foo")
 
 
 async def test_response_body_completed_stream() -> None:

--- a/packages/smithy-http/tests/unit/aio/test_crt.py
+++ b/packages/smithy-http/tests/unit/aio/test_crt.py
@@ -12,7 +12,7 @@ from awscrt.http import HttpClientStream  # type: ignore
 from smithy_core import URI
 from smithy_http import Fields
 from smithy_http.aio import HTTPRequest
-from smithy_http.aio.crt import AWSCRTHTTPClient, PipeByteStream, CRTResponseBody
+from smithy_http.aio.crt import AWSCRTHTTPClient, BufferableByteStream, CRTResponseBody
 
 
 def test_deepcopy_client() -> None:
@@ -38,52 +38,62 @@ async def test_client_marshal_request() -> None:
 
 
 def test_stream_write() -> None:
-    stream = PipeByteStream()
+    stream = BufferableByteStream()
     stream.write(b"foo")
-    stream.close()
     assert stream.read() == b"foo"
 
 
+def test_stream_reads_individual_chunks() -> None:
+    stream = BufferableByteStream()
+    stream.write(b"foo")
+    stream.write(b"bar")
+    assert stream.read() == b"foo"
+    assert stream.read() == b"bar"
+
+
+def test_stream_empty_read() -> None:
+    stream = BufferableByteStream()
+    with pytest.raises(BlockingIOError):
+        stream.read()
+
+
 def test_stream_partial_chunk_read() -> None:
-    stream = PipeByteStream()
+    stream = BufferableByteStream()
     stream.write(b"foobar")
     assert stream.read(3) == b"foo"
-    stream.close()
     assert stream.read() == b"bar"
 
 
 def test_stream_write_empty_bytes() -> None:
-    stream = PipeByteStream()
+    stream = BufferableByteStream()
     stream.write(b"")
     stream.write(b"foo")
     stream.write(b"")
-    stream.close()
     assert stream.read() == b"foo"
 
 
 def test_stream_write_non_bytes() -> None:
-    stream = PipeByteStream()
+    stream = BufferableByteStream()
     with pytest.raises(ValueError):
         stream.write(memoryview(b"foo"))
 
 
 def test_closed_stream_write() -> None:
-    stream = PipeByteStream()
+    stream = BufferableByteStream()
     stream.close()
     with pytest.raises(IOError):
         stream.write(b"foo")
 
 
 def test_closed_stream_read() -> None:
-    stream = PipeByteStream()
+    stream = BufferableByteStream()
     stream.write(b"foo")
     stream.close()
-    assert stream.read() == b"foo"
     assert stream.read() == b""
 
 
 def test_done_stream_read() -> None:
-    stream = PipeByteStream()
+    stream = BufferableByteStream()
     stream.write(b"foo")
     stream.end_stream()
     assert stream.read() == b"foo"
@@ -91,14 +101,24 @@ def test_done_stream_read() -> None:
 
 
 def test_end_empty_stream() -> None:
-    stream = PipeByteStream()
+    stream = BufferableByteStream()
     stream.end_stream()
     assert stream.read() == b""
 
 
+def test_stream_read1() -> None:
+    stream = BufferableByteStream()
+    stream.write(b"foo")
+    stream.write(b"bar")
+    assert stream.read1() == b"foo"
+    assert stream.read1() == b"bar"
+    with pytest.raises(BlockingIOError):
+        stream.read()
+
+
 def test_stream_readinto_memoryview() -> None:
     buffer = memoryview(bytearray(b"   "))
-    stream = PipeByteStream()
+    stream = BufferableByteStream()
     stream.write(b"foobar")
     stream.readinto(buffer)
     assert bytes(buffer) == b"foo"
@@ -106,10 +126,20 @@ def test_stream_readinto_memoryview() -> None:
 
 def test_stream_readinto_bytearray() -> None:
     buffer = bytearray(b"   ")
-    stream = PipeByteStream()
+    stream = BufferableByteStream()
     stream.write(b"foobar")
     stream.readinto(buffer)
     assert bytes(buffer) == b"foo"
+
+
+def test_end_stream() -> None:
+    stream = BufferableByteStream()
+    stream.write(b"foo")
+    stream.end_stream()
+
+    assert not stream.closed
+    assert stream.read() == b"foo"
+    assert stream.closed
 
 
 async def test_response_body_completed_stream() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -686,6 +686,7 @@ dependencies = [
 [package.optional-dependencies]
 aiohttp = [
     { name = "aiohttp" },
+    { name = "yarl" },
 ]
 awscrt = [
     { name = "awscrt" },
@@ -693,9 +694,10 @@ awscrt = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", marker = "extra == 'aiohttp'", specifier = ">=3.11.12" },
+    { name = "aiohttp", marker = "extra == 'aiohttp'", specifier = ">=3.11.12,<4.0" },
     { name = "awscrt", marker = "extra == 'awscrt'", specifier = ">=0.23.10" },
     { name = "smithy-core", editable = "packages/smithy-core" },
+    { name = "yarl", marker = "extra == 'aiohttp'" },
 ]
 provides-extras = ["awscrt", "aiohttp"]
 


### PR DESCRIPTION

*Description of changes:*
See: https://github.com/alextwoods/aws-crt-python/pull/1 for the required CRT binding changes.

Uses a pipe to coordinate non-blocking IO reads.  The async task in python writes chunks from the requeset body to the write_fd of a pipe.  The CRT's C code (running in its own internally managed event loop thread) will check for the `read_fd` attribute, and if available will use a blocking OS read without requiring the GIL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
